### PR TITLE
Update Dockerfile for Ren'Py 7.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt-get install --yes bzip2 wget libx11-6
+RUN apt-get install --yes bzip2 wget libx11-6 libXext.x86_64 libXext.x86_64 libXext.x86_64
 
 COPY lint.sh /lint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt-get install --yes bzip2 wget libx11-6 libXext.x86_64 libXtst.x86_64
+RUN apt-get install --yes bzip2 wget libxext6
 
 COPY lint.sh /lint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt-get install --yes bzip2 wget libxext6 libllvm6.0
+RUN apt-get install --yes bzip2 wget libxext6 libllvm6.0 mesa-utils
 
 COPY lint.sh /lint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt-get install --yes bzip2 wget
+RUN apt-get install --yes bzip2 wget libx11-6
 
 COPY lint.sh /lint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt-get install --yes bzip2 wget libx11-6 libXext.x86_64 libXext.x86_64 libXext.x86_64
+RUN apt-get install --yes bzip2 wget libx11-6 libXext.x86_64 libXtst.x86_64
 
 COPY lint.sh /lint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt-get install --yes bzip2 wget libxext6
+RUN apt-get install --yes bzip2 wget libxext6 libllvm6.0
 
 COPY lint.sh /lint.sh
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ This GitHub action allows you to run the linter on a Ren'Py visual novel project
 
 - `sdk-version`: The version of the Ren'Py SDK to use while linting. Will default to `7.3.2` if none is found.
 - `project-dir`: The directory where the project exists. Will default to `'.'` (root) if none is found.
+
+> :warning: If you are targeting Ren'Py v7.4.0+, you **must** use v1.1.1 of this action or greater.


### PR DESCRIPTION
Ren'Py 7.4 introduced some new system requirements and the Dockerfile needed to be updated to keep track of the dependencies needed.

The Dockerfile now installs the following:

- `mesa-utils` (for OpenGL)
- `libx11-6`
- `libxext6`
- `libllvm-6.0`