### PR TITLE
Minor docs change required

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ This GitHub action allows you to run the linter on a Ren'Py visual novel project
 ```
 or to reuse a previously cached download of the sdk utilizing the [GitHub Cache Action](https://github.com/marketplace/actions/cache)
 ```yml
+- name: Get SDK Version from config
+  id: lookupSdkVersion
+  uses: devorbitus/yq-action-output@v1.0
+  with:
+    # The file path would be to wherever this file is located
+    cmd: yq eval '.jobs.build.steps[] | select(.id == "lintProject") | .with.sdk-version' .github/workflows/renpy-linter-action.yml
 - name: Restore Cache
   id: restore-cache
   uses: actions/cache@v2
   with:
     path: ../renpy
-    key: ${{ runner.os }}-sdk-${{ steps.lintProject.with.sdk-version }}
+    key: ${{ runner.os }}-sdk-${{ steps.lookupSdkVersion.outputs.result }}
 - name: Lint VN project
   id: lintProject
   uses: ProjectAliceDev/renpy-lint-action@master
@@ -37,7 +43,7 @@ or to reuse a previously cached download of the sdk utilizing the [GitHub Cache 
   uses: actions/cache@v2
   with:
     path: ../renpy
-    key: ${{ runner.os }}-sdk-${{ steps.lintProject.with.sdk-version }}
+    key: ${{ runner.os }}-sdk-${{ steps.lookupSdkVersion.outputs.result }}
 ```
 
 **Required Parameters:**

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ or to reuse a previously cached download of the sdk utilizing the [GitHub Cache 
   uses: actions/cache@v2
   with:
     path: ../renpy
-    key:   ${{ runner.os }}-sdk-${{ steps.lintProject.with.sdk-version }}
+    key: ${{ runner.os }}-sdk-${{ steps.lintProject.with.sdk-version }}
 - name: Lint VN project
   id: lintProject
   uses: ProjectAliceDev/renpy-lint-action@master
@@ -37,7 +37,7 @@ or to reuse a previously cached download of the sdk utilizing the [GitHub Cache 
   uses: actions/cache@v2
   with:
     path: ../renpy
-    key:  ${{ runner.os }}-sdk-${{ steps.lintProject.with.sdk-version }}
+    key: ${{ runner.os }}-sdk-${{ steps.lintProject.with.sdk-version }}
 ```
 
 **Required Parameters:**


### PR DESCRIPTION
It turns out the "steps" context for GitHub Actions does NOT have access to the "with" section so the previous configuration will cache the same folder for every setting. This new configuration will actually read the SDK version number from the YAML file itself for caching purposes.